### PR TITLE
Fix/15 step summaries accessibility

### DIFF
--- a/css/step-by-step-nav.css
+++ b/css/step-by-step-nav.css
@@ -58,10 +58,29 @@ ul.step-list li .btn {
 .step-by-step-pages .step-by-step-pages__relationship {
   display: block;
 }
-.step-by-step-pages .step-master {
-  font-size: 16px;
-  font-weight: 400 !important;
+.step-by-step-pages .step-master,
+.step-by-step-pages ol.step-list .step .step__title .step-show {
+  background: none;
+  border: none;
   color: #0059A4;
+  font-size: 16px;
+  font-weight: 400;
+  text-decoration: underline;
+}
+.step-by-step-pages ol.step-list .step .step__title .step-show {
+  font-size: .875rem;
+  color: #121212;
+}
+.step-by-step-pages .step-master:focus,
+.step-by-step-pages .step-master:hover,
+.step-by-step-pages .step-master:active,
+.step-by-step-pages ol.step-list .step .step__title .step-show:focus,
+.step-by-step-pages ol.step-list .step .step__title .step-show:hover,
+.step-by-step-pages ol.step-list .step .step__title .step-show:active {
+  background-color: #fb0;
+  color: #121212;
+  text-decoration: none;
+  box-shadow: 0 0 0 0.125rem #fb0;
 }
 .step-by-step-pages ol.step-list {
   list-style-type: none;
@@ -117,11 +136,6 @@ ul.step-list li .btn {
 .step-by-step-pages ol.step-list .step .step__title a {
   color: #121212;
   display: block;
-}
-.step-by-step-pages ol.step-list .step .step__title a.step-show {
-  font-size: 14px;
-  color: #0059A4;
-  text-decoration: underline;
 }
 .step-by-step-pages ol.step-list .step .step__summary p {
   margin-top: 0;

--- a/js/step-by-step-nav.js
+++ b/js/step-by-step-nav.js
@@ -4,74 +4,91 @@
  */
 
 (function($, Drupal, drupalSettings) {
-  
-  // add initial step view links based on active step status
-  function titlesum(){ 
-    $("ol.step-list .step").each(function() {
-        if ($(this).hasClass('step--active')) {
-            $(this).find('.step__title').append("<span class='step-summary-container'><a href='#' class='step-show'>Hide step summary</a></span>");
-            $(this).find('.step__summary').addClass('step-show-summary');
-        } else {
-            $(this).find('.step__title').append("<span class='step-summary-container'><a href='#' class='step-show'>Show step summary</a></span>");
-        };
-     });
-    }
 
-  // switch text in and out (more precise that toggling)
-  function stepstext(){
-    $("ol.step-list .step").each(function() {
-      if ($(".step__summary").is(':visible')) {
-         $(this).find('.step-show').text('Hide step summary');
-      } else {
-         $(this).find('.step-show').text('Show step summary');
-      }
-    });
-  }
+  const stepByStep = {};
+  stepByStep.showAllText = 'Show summaries';
+  stepByStep.hideAllText = 'Hide summaries';
+  stepByStep.showStepText = 'Show step summary';
+  stepByStep.hideStepText = 'Hide step summary';
 
-  // run titlesum function on load
-  titlesum();
+  // Add hide/show buttons for each step, accounting for active step if present. Active step is shown open by default
 
-  // add the hide all option on load
-  if ($(".step__summary").is(':visible')) {
-  $("<div class='summaries-control'><i class='fas fa-eye-slash'></i><a href='#' class='step-master ml-2'>Hide summaries</a></div>").insertBefore("ol.step-list");
-  } else {
-    $("<div class='summaries-control'><i class='fas fa-eye'></i><a href='#' class='step-master ml-2'>Show summaries</a></div>").insertBefore("ol.step-list");
-  };
+  // Add hide/show button for all steps, default is 'Show all' for overview and all step pages, as per GDS
 
-  // handle show hide of summaries
-  $('.step-show').on("click", function (e){
-    $(this).parent().parent().siblings(".step__summary").toggleClass("step-show-summary");
-    if ($(this).parent().parent().siblings(".step__summary").is(':visible')) {
-      $(this).text('Hide step summary');                
-    } else {
-      $(this).text('Show step summary');                
-    }
-    e.preventDefault();
-  });
-
-  // handle hide show of all summaries
-  $('.step-master').on("click", function (e){
-   if ($(".step__summary").is(':visible')) {
-    $(".step__summary").removeClass("step-show-summary");
-      $(this).text('Show summaries');
-      $(this).prev().addClass('fa-eye').removeClass('fa-eye-slash');         
-    } else {
-      $(".step__summary").addClass("step-show-summary");
-      $(this).text('Hide summaries'); 
-      $(this).prev().addClass('fa-eye-slash').removeClass('fa-eye');          
-    }
-    
-    stepstext(); // update the steps text
-    e.preventDefault();
-  });
-  
-
-  Drupal.behaviors.localgov_step_by_step = {
-    attach: function onload(context, settings) {
-      // Custom code goes here.  Please note that this function can get called
-      // more than once after page load.
-      
-
+  function summaryVisiblity(elements, cmd) {
+    switch(cmd) {
+      case 'show':
+        elements.each(function() {
+          var stepTitle = $(this).parents('.step__title').find('a').text();
+          $(this).parents('.step').find('.step__summary').addClass('step-show-summary');
+          $(this).text(stepByStep.hideStepText);
+          $(this).attr("aria-expanded", "true");
+          $(this).attr('aria-label', "Hide " + stepTitle + " summary");
+        });
+        // Hide all control visible if all steps are shown
+        if ($('.step__summary').length === $('.step-show-summary').length) {
+          $('.step-master').text(stepByStep.hideAllText);
+          $('.summaries-control i').addClass('fa-eye-slash').removeClass('fa-eye');
+        }
+        break;
+      case 'hide':
+        elements.each(function() {
+          var stepTitle = $(this).parents('.step__title').find('a').text();
+          $(this).parents('.step').find('.step__summary').removeClass('step-show-summary');
+          $(this).attr("aria-expanded", "false");
+          $(this).text(stepByStep.showStepText);
+          $(this).attr('aria-label', "Show " + stepTitle + " summary");
+        });
+        // Show all control visible if any steps are hidden
+        $('.step-master').text(stepByStep.showAllText);
+        $('.summaries-control i').addClass('fa-eye').removeClass('fa-eye-slash');
+        break;
     }
   }
+
+  // Insert show all button
+  $("<div class='summaries-control'><i class='fas fa-eye'></i><button aria-expanded='false' class='step-master ml-2'>" + stepByStep.showAllText + "</button></div>").insertBefore("ol.step-list");
+
+  // Insert hide/show button for each step
+  function stepSummaryButton(isVisible, stepTitle) {
+    var container = $("<span class='step-summary-container'>");
+    var button = $("<button class='step-show'>");
+    button.attr('aria-expanded', isVisible ? "true" : "false");
+    button.attr('aria-label', (isVisible ? "Hide " : "Show ") + stepTitle + " summary");
+    button.text(isVisible ? stepByStep.hideStepText : stepByStep.showStepText);
+    container.append(button);
+    return container;
+  }
+
+  $("ol.step-list .step").each(function() {
+    var isVisible = $(this).hasClass('step--active');
+    var stepTitle = $(this).find('.step__title').text();
+    if (isVisible) {
+      $(this).find('.step__summary').addClass('step-show-summary');
+    }
+    $(this).find('.step__title').append(stepSummaryButton(isVisible, stepTitle));
+  });
+
+  // Show / hide all
+  $('.step-master').on("click", function () {
+    $('.summaries-control i').toggleClass('fa-eye fa-eye-slash');
+    if ($(this).text() === stepByStep.showAllText) {
+      $(this).text(stepByStep.hideAllText).attr('aria-expanded', true);
+      summaryVisiblity($('.step-show'), 'show');
+    } else {
+      $(this).text(stepByStep.showAllText).attr('aria-expanded', false);
+      summaryVisiblity($('.step-show'), 'hide');
+    }
+  });
+
+  // Show / hide single step
+  $('.step-show').on("click", function () {
+    $(this).parents('.step').find('.step__summary').toggleClass('step-show-summary');
+    if ($(this).text() === stepByStep.showStepText) {
+      summaryVisiblity($(this), 'show');
+    } else {
+      summaryVisiblity($(this), 'hide');
+    }
+  });
+
 })(jQuery, Drupal, drupalSettings);

--- a/js/step-by-step-nav.js
+++ b/js/step-by-step-nav.js
@@ -11,7 +11,7 @@
   stepByStep.showStepText = 'Show step summary';
   stepByStep.hideStepText = 'Hide step summary';
 
-  // Set visibility based on specified button.step-show elements
+  // Set visibility based on specified button.step-show elements.
   function summaryVisiblity(elements, cmd) {
     switch(cmd) {
       case 'show':
@@ -22,12 +22,13 @@
           $(this).attr("aria-expanded", "true");
           $(this).attr('aria-label', "Hide " + stepTitle + " summary");
         });
-        // 'Hide all' control displayed if all steps are shown
+        // 'Hide all' control displayed if all steps are shown.
         if ($('.step__summary').length === $('.step-show-summary').length) {
           $('.step-master').text(stepByStep.hideAllText);
           $('.summaries-control i').addClass('fa-eye-slash').removeClass('fa-eye');
         }
         break;
+
       case 'hide':
         elements.each(function() {
           var stepTitle = $(this).parents('.step__title').find('a').text();
@@ -36,25 +37,25 @@
           $(this).text(stepByStep.showStepText);
           $(this).attr('aria-label', "Show " + stepTitle + " summary");
         });
-        // 'Show all' control displayed if any steps are hidden
+        // 'Show all' control displayed if any steps are hidden.
         $('.step-master').text(stepByStep.showAllText);
         $('.summaries-control i').addClass('fa-eye').removeClass('fa-eye-slash');
         break;
     }
   }
 
-  // Insert show all button
+  // Insert show all button.
   $("<div class='summaries-control'><i class='fas fa-eye'></i><button aria-expanded='false' class='step-master ml-2'>" + stepByStep.showAllText + "</button></div>").insertBefore("ol.step-list");
 
-  // Insert hide/show button for each step
+  // Insert hide/show button for each step.
   function stepSummaryButton(isVisible, stepTitle) {
-    var container = $("<span class='step-summary-container'>");
-    var button = $("<button class='step-show'>");
-    button.attr('aria-expanded', isVisible ? "true" : "false");
-    button.attr('aria-label', (isVisible ? "Hide " : "Show ") + stepTitle + " summary");
-    button.text(isVisible ? stepByStep.hideStepText : stepByStep.showStepText);
-    container.append(button);
-    return container;
+    var $container = $("<span class='step-summary-container'>");
+    var $button = $("<button class='step-show'>");
+    $button.attr('aria-expanded', isVisible ? "true" : "false");
+    $button.attr('aria-label', (isVisible ? "Hide " : "Show ") + stepTitle + " summary");
+    $button.text(isVisible ? stepByStep.hideStepText : stepByStep.showStepText);
+    $container.append($button);
+    return $container;
   }
 
   $("ol.step-list .step").each(function() {
@@ -66,7 +67,7 @@
     $(this).find('.step__title').append(stepSummaryButton(isVisible, stepTitle));
   });
 
-  // Show / hide all
+  // Show / hide all.
   $('.step-master').on("click", function () {
     $('.summaries-control i').toggleClass('fa-eye fa-eye-slash');
     if ($(this).text() === stepByStep.showAllText) {
@@ -78,7 +79,7 @@
     }
   });
 
-  // Show / hide single step
+  // Show / hide single step.
   $('.step-show').on("click", function () {
     $(this).parents('.step').find('.step__summary').toggleClass('step-show-summary');
     if ($(this).text() === stepByStep.showStepText) {

--- a/js/step-by-step-nav.js
+++ b/js/step-by-step-nav.js
@@ -11,10 +11,7 @@
   stepByStep.showStepText = 'Show step summary';
   stepByStep.hideStepText = 'Hide step summary';
 
-  // Add hide/show buttons for each step, accounting for active step if present. Active step is shown open by default
-
-  // Add hide/show button for all steps, default is 'Show all' for overview and all step pages, as per GDS
-
+  // Set visibility based on specified button.step-show elements
   function summaryVisiblity(elements, cmd) {
     switch(cmd) {
       case 'show':
@@ -25,7 +22,7 @@
           $(this).attr("aria-expanded", "true");
           $(this).attr('aria-label', "Hide " + stepTitle + " summary");
         });
-        // Hide all control visible if all steps are shown
+        // 'Hide all' control displayed if all steps are shown
         if ($('.step__summary').length === $('.step-show-summary').length) {
           $('.step-master').text(stepByStep.hideAllText);
           $('.summaries-control i').addClass('fa-eye-slash').removeClass('fa-eye');
@@ -39,7 +36,7 @@
           $(this).text(stepByStep.showStepText);
           $(this).attr('aria-label', "Show " + stepTitle + " summary");
         });
-        // Show all control visible if any steps are hidden
+        // 'Show all' control displayed if any steps are hidden
         $('.step-master').text(stepByStep.showAllText);
         $('.summaries-control i').addClass('fa-eye').removeClass('fa-eye-slash');
         break;

--- a/tests/src/FunctionalJavascript/StepByStepSummariesTest.php
+++ b/tests/src/FunctionalJavascript/StepByStepSummariesTest.php
@@ -1,0 +1,75 @@
+<?php
+
+namespace Drupal\Tests\localgov_alert_banner\FunctionalJavascript;
+
+use Drupal\FunctionalJavascriptTests\WebDriverTestBase;
+
+/**
+ * Functional tests for LocalGovDrupal Alert banner block.
+ */
+class StepByStepSummariesTest extends WebDriverTestBase {
+
+  /**
+   * {@inheritdoc}
+   */
+  protected $defaultTheme = 'localgov_theme';
+
+  /**
+   * {@inheritdoc}
+   */
+  protected $profile = 'localgov';
+
+  /**
+   * {@inheritdoc}
+   */
+  public static $modules = [
+    'localgov_alert_banner',
+  ];
+
+  /**
+   * Test alert banner hide link.
+   */
+  public function testAlertBannerHide() {
+    // Set up an alert banner.
+    $title = $this->randomMachineName(8);
+    $alert_message = 'Alert message: ' . $this->randomMachineName(16);
+    $alert = $this->container->get('entity_type.manager')->getStorage('localgov_alert_banner')
+      ->create([
+        'type' => 'localgov_alert_banner',
+        'title' => $title,
+        'short_description' => $alert_message,
+        'type_of_alert' => 'minor',
+        'status' => TRUE,
+      ]);
+    $alert->save();
+
+    // Load the front page.
+    $this->drupalGet('<front>');
+
+    // Find and click hide link.
+    $page = $this->getSession()->getPage();
+    $button = $page->findButton('Hide');
+    $this->assertNotEmpty($button);
+    $button->click();
+
+    // Check cookie set and banner not visible.
+    $this->assertSession()->CookieExists('hide-alert-banner-token');
+    $this->assertSession()->pageTextNotContains($alert_message);
+
+    // Test on login page.
+    $this->drupalGet('/user');
+    $this->assertSession()->pageTextNotContains($alert_message);
+
+    // Update alert message.
+    $title = $this->randomMachineName(8);
+    $alert->set('title', ['value' => $title]);
+    $alert->save();
+
+    // Load the front page and check that banner displays and cookie token is
+    // no longer valid.
+    $this->drupalGet('<front>');
+    $this->assertSession()->pageTextContains($title);
+
+  }
+
+}

--- a/tests/src/FunctionalJavascript/StepByStepSummariesTest.php
+++ b/tests/src/FunctionalJavascript/StepByStepSummariesTest.php
@@ -30,7 +30,7 @@ class StepByStepSummariesTest extends WebDriverTestBase {
   ];
 
   /**
-   * Test step summary visibility
+   * Test step summary visibility.
    */
   public function testStepSummaryVisibility() {
 
@@ -43,7 +43,7 @@ class StepByStepSummariesTest extends WebDriverTestBase {
     ]);
 
     // Create three step-by-step page nodes.
-    $pages = array();
+    $pages = [];
     for ($x = 1; $x < 4; $x++) {
       $pages[$x] = $this->createNode([
         'title' => 'Step ' . $x . ' page',
@@ -58,7 +58,7 @@ class StepByStepSummariesTest extends WebDriverTestBase {
     // Load overview page.
     $this->drupalGet('/node/1');
 
-    //Check summaries not visible.
+    // Check summaries not visible.
     $this->assertSession()->pageTextNotContains('Step 1 summary');
 
     $page = $this->getSession()->getPage();

--- a/tests/src/FunctionalJavascript/StepByStepSummariesTest.php
+++ b/tests/src/FunctionalJavascript/StepByStepSummariesTest.php
@@ -43,9 +43,8 @@ class StepByStepSummariesTest extends WebDriverTestBase {
     ]);
 
     // Create three step-by-step page nodes.
-    $pages = [];
     for ($x = 1; $x < 4; $x++) {
-      $pages[$x] = $this->createNode([
+      $this->createNode([
         'title' => 'Step ' . $x . ' page',
         'localgov_step_section_title' => 'Step ' . $x . ' title',
         'type' => 'localgov_step_by_step_page',

--- a/tests/src/FunctionalJavascript/StepByStepSummariesTest.php
+++ b/tests/src/FunctionalJavascript/StepByStepSummariesTest.php
@@ -3,9 +3,10 @@
 namespace Drupal\Tests\localgov_alert_banner\FunctionalJavascript;
 
 use Drupal\FunctionalJavascriptTests\WebDriverTestBase;
+use Drupal\node\NodeInterface;
 
 /**
- * Functional tests for LocalGovDrupal Alert banner block.
+ * Javascript tests for LocalGovDrupal step-by-step blocks.
  */
 class StepByStepSummariesTest extends WebDriverTestBase {
 
@@ -20,56 +21,65 @@ class StepByStepSummariesTest extends WebDriverTestBase {
   protected $profile = 'localgov';
 
   /**
-   * {@inheritdoc}
+   * Modules to enable.
+   *
+   * @var array
    */
   public static $modules = [
-    'localgov_alert_banner',
+    'localgov_step_by_step',
   ];
 
   /**
-   * Test alert banner hide link.
+   * Test step summary visibility
    */
-  public function testAlertBannerHide() {
-    // Set up an alert banner.
-    $title = $this->randomMachineName(8);
-    $alert_message = 'Alert message: ' . $this->randomMachineName(16);
-    $alert = $this->container->get('entity_type.manager')->getStorage('localgov_alert_banner')
-      ->create([
-        'type' => 'localgov_alert_banner',
-        'title' => $title,
-        'short_description' => $alert_message,
-        'type_of_alert' => 'minor',
-        'status' => TRUE,
+  public function testStepSummaryVisibility() {
+
+    // Create step-by-step overview node.
+    $overview_title = $this->randomMachineName(8);
+    $overview = $this->createNode([
+      'title' => $overview_title,
+      'type' => 'localgov_step_by_step_overview',
+      'status' => NodeInterface::PUBLISHED,
+    ]);
+
+    // Create three step-by-step page nodes.
+    $pages = array();
+    for ($x = 1; $x < 4; $x++) {
+      $pages[$x] = $this->createNode([
+        'title' => 'Step ' . $x . ' page',
+        'localgov_step_section_title' => 'Step ' . $x . ' title',
+        'type' => 'localgov_step_by_step_page',
+        'localgov_step_summary' => 'Step ' . $x . ' summary.',
+        'status' => NodeInterface::PUBLISHED,
+        'localgov_step_parent' => ['target_id' => $overview->id()],
       ]);
-    $alert->save();
+    }
 
-    // Load the front page.
-    $this->drupalGet('<front>');
+    // Load overview page.
+    $this->drupalGet('/node/1');
 
-    // Find and click hide link.
+    //Check summaries not visible.
+    $this->assertSession()->pageTextNotContains('Step 1 summary');
+
     $page = $this->getSession()->getPage();
-    $button = $page->findButton('Hide');
-    $this->assertNotEmpty($button);
-    $button->click();
 
-    // Check cookie set and banner not visible.
-    $this->assertSession()->CookieExists('hide-alert-banner-token');
-    $this->assertSession()->pageTextNotContains($alert_message);
+    // Test 'Show summaries' button.
+    $page->pressButton('Show summaries');
+    $this->assertSession()->pageTextContains('Step 1 summary');
+    $this->assertSession()->pageTextContains('Step 2 summary');
+    $this->assertSession()->pageTextContains('Step 3 summary');
 
-    // Test on login page.
-    $this->drupalGet('/user');
-    $this->assertSession()->pageTextNotContains($alert_message);
+    // Test 'Hide summaries' button.
+    $page->pressButton('Hide summaries');
+    $this->assertSession()->pageTextNotContains('Step 1 summary');
+    $this->assertSession()->pageTextNotContains('Step 2 summary');
+    $this->assertSession()->pageTextNotContains('Step 3 summary');
 
-    // Update alert message.
-    $title = $this->randomMachineName(8);
-    $alert->set('title', ['value' => $title]);
-    $alert->save();
-
-    // Load the front page and check that banner displays and cookie token is
-    // no longer valid.
-    $this->drupalGet('<front>');
-    $this->assertSession()->pageTextContains($title);
-
+    // Load step 2 page and test summary visibility.
+    $this->drupalGet('/node/3');
+    $this->assertSession()->pageTextNotContains('Step 1 summary');
+    $this->assertSession()->pageTextNotContains('Step 3 summary');
+    $this->assertSession()->pageTextContains('Step 2 summary');
   }
 
 }


### PR DESCRIPTION
Closes #15:

- Replaces show/hide links for step summaries with buttons
- Styles buttons to match existing link styling
- Adds aria-label and aria-expanded attributes
- Fixes show/hide all behaviour, aligning with GDS pattern
- Adds tests for js functions

Presentational styling should probably move to localgov_theme in the future.