### PR TITLE
Replace previous/next buttons with links

### DIFF
--- a/localgov_step_by_step.module
+++ b/localgov_step_by_step.module
@@ -148,10 +148,10 @@ function _localgov_step_by_step_find_prev_next_steps(string $current_nid, array 
 
   $node_storage = \Drupal::entityTypeManager()->getStorage('node');
   if ($variables['has_next_step']) {
-    $variables['next_step_title'] = $node = $node_storage->load($variables['next_step_nid'])->title->value;
+    $variables['next_step_title'] = $node_storage->load($variables['next_step_nid'])->title->value;
   }
   if ($variables['has_prev_step']) {
-    $variables['prev_step_title'] = $node = $node_storage->load($variables['prev_step_nid'])->title->value;
+    $variables['prev_step_title'] = $node_storage->load($variables['prev_step_nid'])->title->value;
   }
 }
 

--- a/localgov_step_by_step.module
+++ b/localgov_step_by_step.module
@@ -145,6 +145,14 @@ function _localgov_step_by_step_find_prev_next_steps(string $current_nid, array 
 
   $is_first_step = ($next_step_index === 1);
   $variables['next_step_link_text'] = $is_first_step ? t('Next Step') : t('Next Step');
+
+  $node_storage = \Drupal::entityTypeManager()->getStorage('node');
+  if ($variables['has_next_step']) {
+    $variables['next_step_title'] = $node = $node_storage->load($variables['next_step_nid'])->title->value;
+  }
+  if ($variables['has_prev_step']) {
+    $variables['prev_step_title'] = $node = $node_storage->load($variables['prev_step_nid'])->title->value;
+  }
 }
 
 /**

--- a/templates/views-view-list--localgov-step-by-step-navigation--prev-next.html.twig
+++ b/templates/views-view-list--localgov-step-by-step-navigation--prev-next.html.twig
@@ -47,14 +47,13 @@
   <{{ list.type }}{{ list.attributes }}>
     {% if has_prev_step %}
       <li{{ rows[prev_step_index].attributes.addClass('step--prev') }}>
-        <button type="button" onclick="location.href='{{ path('entity.node.canonical', {'node': prev_step_nid }) }}'" class="btn btn-carbon"><span class="fa fa-chevron-left"></span>{{ prev_step_link_text }}</button>
+        <a href="{{ path('entity.node.canonical', {'node': prev_step_nid }) }}" class="btn btn-carbon" aria-label="Previous step: {{ prev_step_title }}"><span class="fa fa-chevron-left"></span>{{ prev_step_link_text }}</a>
       </li>
     {% endif %}
 
     {% if has_next_step %}
       <li{{ rows[next_step_index].attributes.addClass('step--next') }}>
-        
-        <button type="button" onclick="location.href='{{ path('entity.node.canonical', {'node': next_step_nid }) }}'" class="btn btn-primary"><span class="fa fa-chevron-right"></span>{{ next_step_link_text }}</button>
+        <a href="{{ path('entity.node.canonical', {'node': next_step_nid }) }}" class="btn btn-primary" aria-label="Next step: {{ next_step_title }}"><span class="fa fa-chevron-right"></span>{{ next_step_link_text }}</a>
       </li>
     {% endif %}
   </{{ list.type }}>


### PR DESCRIPTION
Closes #16. This PR:

- Replaces next / previous step buttons with links
- Links use aria-label attributes to provide context to users of assistive technologies

Requires [/localgovdrupal/localgov_theme/pull/43](/localgovdrupal/localgov_theme/pull/43) for updated link styling