### PR TITLE
Unpublished content in navigation

### DIFF
--- a/config/install/views.view.localgov_step_by_step_navigation.yml
+++ b/config/install/views.view.localgov_step_by_step_navigation.yml
@@ -11,8 +11,6 @@ dependencies:
     - node
     - text
     - user
-_core:
-  default_config_hash: uLJVkWkbzJp38WespuE3bjVEmfr34-HPF37RRnuDjng
 id: localgov_step_by_step_navigation
 label: 'Step by step navigation'
 module: views
@@ -20,7 +18,6 @@ description: ''
 tag: ''
 base_table: node_field_data
 base_field: nid
-core: 8.x
 display:
   default:
     display_plugin: default
@@ -329,17 +326,45 @@ display:
           field_api_classes: false
           plugin_id: field
       filters:
-        status:
-          value: '1'
+        status_extra:
+          id: status_extra
           table: node_field_data
-          field: status
-          plugin_id: boolean
-          entity_type: node
-          entity_field: status
-          id: status
-          expose:
-            operator: ''
+          field: status_extra
+          relationship: localgov_step_by_step_pages_1
+          group_type: group
+          admin_label: ''
+          operator: '='
+          value: false
           group: 1
+          exposed: false
+          expose:
+            operator_id: ''
+            label: ''
+            description: ''
+            use_operator: false
+            operator: ''
+            operator_limit_selection: false
+            operator_list: {  }
+            identifier: ''
+            required: false
+            remember: false
+            multiple: false
+            remember_roles:
+              authenticated: authenticated
+          is_grouped: false
+          group_info:
+            label: ''
+            description: ''
+            identifier: ''
+            optional: true
+            widget: select
+            multiple: false
+            remember: false
+            default_group: All
+            default_group_multiple: {  }
+            group_items: {  }
+          entity_type: node
+          plugin_id: node_status
       sorts: {  }
       title: 'Step by step navigation'
       header: {  }
@@ -422,12 +447,14 @@ display:
         operator: AND
         groups:
           1: AND
+      display_extenders: {  }
     cache_metadata:
       max-age: -1
       contexts:
         - 'languages:language_content'
         - 'languages:language_interface'
         - url
+        - user
         - 'user.node_grants:view'
         - user.permissions
       tags:
@@ -464,12 +491,14 @@ display:
           inline: {  }
           separator: ''
           hide_empty: false
+      display_extenders: {  }
     cache_metadata:
       max-age: -1
       contexts:
         - 'languages:language_content'
         - 'languages:language_interface'
         - url
+        - user
         - 'user.node_grants:view'
         - user.permissions
       tags:
@@ -502,12 +531,14 @@ display:
         row: true
         css_class: false
       css_class: 'step-by-step-pages step-by-step-pages--nav'
+      display_extenders: {  }
     cache_metadata:
       max-age: -1
       contexts:
         - 'languages:language_content'
         - 'languages:language_interface'
         - url
+        - user
         - 'user.node_grants:view'
         - user.permissions
       tags:
@@ -579,15 +610,17 @@ display:
       css_class: 'step-by-step-pages step-by-step-pages--nav'
       display_description: 'List Step by step pages belonging to a Step by step overview.'
       block_description: 'Step by step navigation for Step overview'
+      display_extenders: {  }
     cache_metadata:
       max-age: -1
       contexts:
         - 'languages:language_content'
         - 'languages:language_interface'
         - url
+        - user
         - 'user.node_grants:view'
         - user.permissions
       tags:
-        - 'config:field.storage.node.localgov_step_by_step_parent'
-        - 'config:field.storage.node.localgov_step_by_step_section_title'
-        - 'config:field.storage.node.localgov_step_by_step_summary'
+        - 'config:field.storage.node.localgov_step_parent'
+        - 'config:field.storage.node.localgov_step_section_title'
+        - 'config:field.storage.node.localgov_step_summary'

--- a/localgov_step_by_step.install
+++ b/localgov_step_by_step.install
@@ -1,12 +1,12 @@
 <?php
 
-use Drupal\Component\Serialization\Yaml;
-use Drupal\views\Entity\View;
-
 /**
  * @file
  * Install, update and uninstall functions for the LocalGov Step By Step module.
  */
+
+use Drupal\Component\Serialization\Yaml;
+use Drupal\views\Entity\View;
 
 /**
  * Implements hook_install().

--- a/localgov_step_by_step.install
+++ b/localgov_step_by_step.install
@@ -1,5 +1,7 @@
 <?php
 
+use Drupal\Component\Serialization\Yaml;
+
 /**
  * @file
  * Install, update and uninstall functions for the LocalGov Step By Step module.
@@ -21,5 +23,81 @@ function localgov_step_by_step_install() {
     $generator = \Drupal::service('simple_sitemap.generator');
     $generator->setBundleSettings('node', 'localgov_step_by_step_overview', ['index' => TRUE, 'priority' => 0.5]);
     $generator->setBundleSettings('node', 'localgov_step_by_step_page', ['index' => TRUE, 'priority' => 0.5]);
+  }
+}
+
+/**
+ * Update navigation view for step published status.
+ */
+function localgov_step_by_step_update_8001() {
+  $config_factory = \Drupal::configFactory();
+  $navigation_view = $config_factory->getEditable('views.view.localgov_step_by_step_navigation');
+  $display = $navigation_view->get('display');
+  $filters = $display['default']['display_options']['filters'];
+  $relationships = $display['default']['display_options']['relationships'];
+  // Don't alter the view if the relevant parts have been changed on the site.
+  if (
+    // Check just has the one filter and these haven't been changed.
+    count($filters) == 1 &&
+    isset($filters['status']) &&
+    // The filters of the default display have not been changed from old
+    // default status of the base node.
+    $filters['status']['value'] == 1 &&
+    empty($filters['status']['expose']['operator']) &&
+    // The relationship for the listed step pages is the same.
+    isset($relationships['localgov_step_by_step_pages_1']) &&
+    $relationships['localgov_step_by_step_pages_1']['table'] == 'node__localgov_step_by_step_pages' &&
+    $relationships['localgov_step_by_step_pages_1']['field'] == 'localgov_step_by_step_pages'
+  ) {
+    // Replace with published or admin on the displayed step node itself,
+    // as per new view.
+    $display['default']['display_options']['filters'] = Yaml::decode(<<<EOY
+status_extra:
+  id: status_extra
+  table: node_field_data
+  field: status_extra
+  relationship: localgov_step_by_step_pages_1
+  group_type: group
+  admin_label: ''
+  operator: '='
+  value: false
+  group: 1
+  exposed: false
+  expose:
+    operator_id: ''
+    label: ''
+    description: ''
+    use_operator: false
+    operator: ''
+    operator_limit_selection: false
+    operator_list: {  }
+    identifier: ''
+    required: false
+    remember: false
+    multiple: false
+    remember_roles:
+      authenticated: authenticated
+  is_grouped: false
+  group_info:
+    label: ''
+    description: ''
+    identifier: ''
+    optional: true
+    widget: select
+    multiple: false
+    remember: false
+    default_group: All
+    default_group_multiple: {  }
+    group_items: {  }
+  entity_type: node
+  plugin_id: node_status
+EOY
+    );
+    $navigation_view->set('display', $display);
+    $navigation_view->save();
+    return t('Step by step navigation view published filter updated.');
+  }
+  else {
+    return t('Step by step navigation view not updated. See release notes for more info.');
   }
 }

--- a/localgov_step_by_step.install
+++ b/localgov_step_by_step.install
@@ -1,6 +1,7 @@
 <?php
 
 use Drupal\Component\Serialization\Yaml;
+use Drupal\views\Entity\View;
 
 /**
  * @file
@@ -30,8 +31,7 @@ function localgov_step_by_step_install() {
  * Update navigation view for step published status.
  */
 function localgov_step_by_step_update_8001() {
-  $config_factory = \Drupal::configFactory();
-  $navigation_view = $config_factory->getEditable('views.view.localgov_step_by_step_navigation');
+  $navigation_view = View::load('localgov_step_by_step_navigation');
   $display = $navigation_view->get('display');
   $filters = $display['default']['display_options']['filters'];
   $relationships = $display['default']['display_options']['relationships'];

--- a/tests/src/FunctionalJavascript/StepByStepSummariesTest.php
+++ b/tests/src/FunctionalJavascript/StepByStepSummariesTest.php
@@ -42,9 +42,10 @@ class StepByStepSummariesTest extends WebDriverTestBase {
       'status' => NodeInterface::PUBLISHED,
     ]);
 
+    $step_pages = [];
     // Create three step-by-step page nodes.
     for ($x = 1; $x < 4; $x++) {
-      $this->createNode([
+      $step_pages[$x] = $this->createNode([
         'title' => 'Step ' . $x . ' page',
         'localgov_step_section_title' => 'Step ' . $x . ' title',
         'type' => 'localgov_step_by_step_page',
@@ -79,6 +80,25 @@ class StepByStepSummariesTest extends WebDriverTestBase {
     $this->assertSession()->pageTextNotContains('Step 1 summary');
     $this->assertSession()->pageTextNotContains('Step 3 summary');
     $this->assertSession()->pageTextContains('Step 2 summary');
+
+    // Unpublish step 2.
+    $step_pages[2]->status = NodeInterface::NOT_PUBLISHED;
+    $step_pages[2]->save();
+    $this->drupalGet('/node/1');
+    // Test 'Show summaries' button.
+    $page->pressButton('Show summaries');
+    $this->assertSession()->pageTextContains('Step 1 summary');
+    $this->assertSession()->pageTextNotContains('Step 2 summary');
+    $this->assertSession()->pageTextContains('Step 3 summary');
+
+    // Delete step 3.
+    $step_pages[3]->delete();
+    $this->drupalGet('/node/1');
+    // Test 'Show summaries' button.
+    $page->pressButton('Show summaries');
+    $this->assertSession()->pageTextContains('Step 1 summary');
+    $this->assertSession()->pageTextNotContains('Step 2 summary');
+    $this->assertSession()->pageTextNotContains('Step 3 summary');
   }
 
 }


### PR DESCRIPTION
Fixes #24 24

Changes the view used for both the list navigation, and the next previous links, to have a admin or published filter on the referenced step page content by relationship.
