### PR TITLE
Update overview teaser view mode to only include summary

### DIFF
--- a/config/install/core.entity_view_display.node.localgov_step_by_step_overview.teaser.yml
+++ b/config/install/core.entity_view_display.node.localgov_step_by_step_overview.teaser.yml
@@ -4,14 +4,12 @@ dependencies:
   config:
     - core.entity_view_mode.node.teaser
     - field.field.node.localgov_step_by_step_overview.body
-    - field.field.node.localgov_step_by_step_overview.localgov_step_description
     - field.field.node.localgov_step_by_step_overview.localgov_step_by_step_pages
+    - field.field.node.localgov_step_by_step_overview.localgov_step_description
     - node.type.localgov_step_by_step_overview
   module:
     - text
     - user
-_core:
-  default_config_hash: XtQgF-Eu3GBjtZiKei29HaTNOUEQuPwT8fRlm0GeGN8
 id: node.localgov_step_by_step_overview.teaser
 targetEntityType: node
 bundle: localgov_step_by_step_overview
@@ -20,17 +18,13 @@ content:
   body:
     label: hidden
     type: text_summary_or_trimmed
-    weight: 101
+    weight: 0
     settings:
       trim_length: 600
     third_party_settings: {  }
     region: content
-  links:
-    weight: 100
-    settings: {  }
-    third_party_settings: {  }
-    region: content
 hidden:
-  localgov_step_description: true
+  links: true
   localgov_step_by_step_pages: true
+  localgov_step_description: true
   search_api_excerpt: true


### PR DESCRIPTION
Closes #32:

- Only includes the summary field in teasers, fixing the presentation of service landing pages with step-by-step children.