### PR TITLE
Fix test namespace

### DIFF
--- a/tests/src/FunctionalJavascript/StepByStepSummariesTest.php
+++ b/tests/src/FunctionalJavascript/StepByStepSummariesTest.php
@@ -1,6 +1,6 @@
 <?php
 
-namespace Drupal\Tests\localgov_alert_banner\FunctionalJavascript;
+namespace Drupal\Tests\localgov_step_by_step\FunctionalJavascript;
 
 use Drupal\FunctionalJavascriptTests\WebDriverTestBase;
 use Drupal\node\NodeInterface;


### PR DESCRIPTION
Fix #55﻿

Previously this was referencing localgov_alert_banner.