### PR TITLE
Add search result highlight to search result highlight display

### DIFF
--- a/config/install/core.entity_view_display.node.localgov_step_by_step_overview.search_result.yml
+++ b/config/install/core.entity_view_display.node.localgov_step_by_step_overview.search_result.yml
@@ -8,25 +8,21 @@ dependencies:
     - field.field.node.localgov_step_by_step_overview.localgov_step_description
     - node.type.localgov_step_by_step_overview
   module:
-    - text
     - user
 id: node.localgov_step_by_step_overview.search_result
 targetEntityType: node
 bundle: localgov_step_by_step_overview
 mode: search_result
 content:
-  body:
-    label: hidden
-    type: text_summary_or_trimmed
-    weight: 0
-    settings:
-      trim_length: 600
+  search_api_excerpt:
+    settings: {  }
     third_party_settings: {  }
+    weight: 0
     region: content
 hidden:
+  body: true
   links: true
   localgov_services_parent: true
   localgov_step_by_step_pages: true
   localgov_step_description: true
   localgov_topic_classified: true
-  search_api_excerpt: true

--- a/config/install/core.entity_view_display.node.localgov_step_by_step_page.search_result.yml
+++ b/config/install/core.entity_view_display.node.localgov_step_by_step_page.search_result.yml
@@ -4,29 +4,24 @@ dependencies:
   config:
     - core.entity_view_mode.node.search_result
     - field.field.node.localgov_step_by_step_page.body
-    - field.field.node.localgov_step_by_step_page.localgov_step_parent
     - field.field.node.localgov_step_by_step_page.localgov_step_section_title
     - field.field.node.localgov_step_by_step_page.localgov_step_summary
     - node.type.localgov_step_by_step_page
   module:
-    - text
     - user
 id: node.localgov_step_by_step_page.search_result
 targetEntityType: node
 bundle: localgov_step_by_step_page
 mode: search_result
 content:
-  body:
-    label: hidden
-    type: text_summary_or_trimmed
-    weight: 0
-    settings:
-      trim_length: 600
+  search_api_excerpt:
+    settings: {  }
     third_party_settings: {  }
+    weight: 0
     region: content
 hidden:
+  body: true
   links: true
   localgov_step_parent: true
   localgov_step_section_title: true
   localgov_step_summary: true
-  search_api_excerpt: true

--- a/tests/src/Functional/PagesIntegrationTest.php
+++ b/tests/src/Functional/PagesIntegrationTest.php
@@ -8,9 +8,10 @@ use Drupal\Tests\BrowserTestBase;
 use Drupal\Tests\node\Traits\NodeCreationTrait;
 use Drupal\Tests\system\Functional\Menu\AssertBreadcrumbTrait;
 use Drupal\Tests\taxonomy\Traits\TaxonomyTestTrait;
+use Drupal\Tests\Traits\Core\CronRunTrait;
 
 /**
- * Tests pages working together with pathauto, services and topics.
+ * Tests pages working together with search, pathauto, services and topics.
  *
  * @group localgov_step_by_step
  */
@@ -19,6 +20,7 @@ class PagesIntegrationTest extends BrowserTestBase {
   use NodeCreationTrait;
   use AssertBreadcrumbTrait;
   use TaxonomyTestTrait;
+  use CronRunTrait;
 
   /**
    * Test breadcrumbs in the Standard profile.
@@ -58,6 +60,8 @@ class PagesIntegrationTest extends BrowserTestBase {
     'localgov_services_navigation',
     'localgov_topics',
     'localgov_step_by_step',
+    'localgov_search',
+    'localgov_search_db',
   ];
 
   /**
@@ -122,6 +126,29 @@ class PagesIntegrationTest extends BrowserTestBase {
     $trail += ['landing-page-1' => 'Landing Page 1'];
     $trail += ['landing-page-1/sublanding-1' => 'Sublanding 1'];
     $this->assertBreadcrumb(NULL, $trail);
+  }
+
+  /**
+   * LocalGov Search integration.
+   */
+  public function testLocalgovSearch() {
+    $body = [
+      'value' => 'Science is the search for truth, that is the effort to understand the world: it involves the rejection of bias, of dogma, of revelation, but not the rejection of morality.',
+      'summary' => 'One of the greatest joys known to man is to take a flight into ignorance in search of knowledge.',
+    ];
+    $node = $this->createNode([
+      'title' => 'Test Step By Step',
+      'body' => $body,
+      'type' => 'localgov_step_by_step_overview',
+      'status' => NodeInterface::PUBLISHED,
+    ]);
+    $this->cronRun();
+
+    $this->drupalGet('search', ['query' => ['s' => 'bias+dogma+revelation']]);
+    $this->assertSession()->pageTextContains('Test Step By Step');
+    $this->assertSession()->responseContains('<strong>bias</strong>');
+    $this->assertSession()->responseContains('<strong>dogma</strong>');
+    $this->assertSession()->responseContains('<strong>revelation</strong>');
   }
 
   /**

--- a/tests/src/Functional/PagesIntegrationTest.php
+++ b/tests/src/Functional/PagesIntegrationTest.php
@@ -136,7 +136,7 @@ class PagesIntegrationTest extends BrowserTestBase {
       'value' => 'Science is the search for truth, that is the effort to understand the world: it involves the rejection of bias, of dogma, of revelation, but not the rejection of morality.',
       'summary' => 'One of the greatest joys known to man is to take a flight into ignorance in search of knowledge.',
     ];
-    $node = $this->createNode([
+    $this->createNode([
       'title' => 'Test Step By Step',
       'body' => $body,
       'type' => 'localgov_step_by_step_overview',


### PR DESCRIPTION
Fix #61
Usual cavet about using search_api as dependency applies
(If not using search_api, the search result display will be blank)
