### PR TITLE
2.0.7 release

### DIFF
--- a/config/install/core.entity_view_display.node.localgov_step_by_step_overview.search_result.yml
+++ b/config/install/core.entity_view_display.node.localgov_step_by_step_overview.search_result.yml
@@ -8,25 +8,21 @@ dependencies:
     - field.field.node.localgov_step_by_step_overview.localgov_step_description
     - node.type.localgov_step_by_step_overview
   module:
-    - text
     - user
 id: node.localgov_step_by_step_overview.search_result
 targetEntityType: node
 bundle: localgov_step_by_step_overview
 mode: search_result
 content:
-  body:
-    label: hidden
-    type: text_summary_or_trimmed
-    weight: 0
-    settings:
-      trim_length: 600
+  search_api_excerpt:
+    settings: {  }
     third_party_settings: {  }
+    weight: 0
     region: content
 hidden:
+  body: true
   links: true
   localgov_services_parent: true
   localgov_step_by_step_pages: true
   localgov_step_description: true
   localgov_topic_classified: true
-  search_api_excerpt: true

--- a/config/install/core.entity_view_display.node.localgov_step_by_step_page.search_result.yml
+++ b/config/install/core.entity_view_display.node.localgov_step_by_step_page.search_result.yml
@@ -4,29 +4,24 @@ dependencies:
   config:
     - core.entity_view_mode.node.search_result
     - field.field.node.localgov_step_by_step_page.body
-    - field.field.node.localgov_step_by_step_page.localgov_step_parent
     - field.field.node.localgov_step_by_step_page.localgov_step_section_title
     - field.field.node.localgov_step_by_step_page.localgov_step_summary
     - node.type.localgov_step_by_step_page
   module:
-    - text
     - user
 id: node.localgov_step_by_step_page.search_result
 targetEntityType: node
 bundle: localgov_step_by_step_page
 mode: search_result
 content:
-  body:
-    label: hidden
-    type: text_summary_or_trimmed
-    weight: 0
-    settings:
-      trim_length: 600
+  search_api_excerpt:
+    settings: {  }
     third_party_settings: {  }
+    weight: 0
     region: content
 hidden:
+  body: true
   links: true
   localgov_step_parent: true
   localgov_step_section_title: true
   localgov_step_summary: true
-  search_api_excerpt: true


### PR DESCRIPTION
* Add search result highlight to search result highlight display

Fix #61
Usual cavet about using search_api as dependency applies (If not using search_api, the search result display will be blank)

* Add LecalGov Search integration test for #61 fix.

* Coding standards: unused variable.

Co-authored-by: ekes <ekes@iskra.net>