### PR TITLE
PR in advance of a 2.0.8 release

### DIFF
--- a/config/install/views.view.localgov_step_by_step_navigation.yml
+++ b/config/install/views.view.localgov_step_by_step_navigation.yml
@@ -20,56 +20,12 @@ base_table: node_field_data
 base_field: nid
 display:
   default:
-    display_plugin: default
     id: default
     display_title: Master
+    display_plugin: default
     position: 0
     display_options:
-      access:
-        type: perm
-        options:
-          perm: 'access content'
-      cache:
-        type: tag
-        options: {  }
-      query:
-        type: views_query
-        options:
-          disable_sql_rewrite: false
-          distinct: false
-          replica: false
-          query_comment: ''
-          query_tags: {  }
-      exposed_form:
-        type: basic
-        options:
-          submit_button: Apply
-          reset_button: false
-          reset_button_label: Reset
-          exposed_sorts_label: 'Sort by'
-          expose_sort_order: true
-          sort_asc_label: Asc
-          sort_desc_label: Desc
-      pager:
-        type: none
-        options:
-          offset: 0
-      style:
-        type: html_list
-        options:
-          grouping: {  }
-          row_class: step
-          default_row_class: false
-          type: ol
-          wrapper_class: ''
-          class: step-list
-      row:
-        type: fields
-        options:
-          default_field_elements: false
-          inline: {  }
-          separator: ''
-          hide_empty: false
+      title: 'Step by step navigation'
       fields:
         nid:
           id: nid
@@ -78,6 +34,9 @@ display:
           relationship: localgov_step_by_step_pages_1
           group_type: group
           admin_label: ''
+          entity_type: node
+          entity_field: nid
+          plugin_id: field
           label: ''
           exclude: true
           alter:
@@ -134,9 +93,6 @@ display:
           multi_type: separator
           separator: ', '
           field_api_classes: false
-          entity_type: node
-          entity_field: nid
-          plugin_id: field
         localgov_step_parent:
           id: localgov_step_parent
           table: node__localgov_step_parent
@@ -144,6 +100,7 @@ display:
           relationship: localgov_step_by_step_pages_1
           group_type: group
           admin_label: ''
+          plugin_id: field
           label: ''
           exclude: true
           alter:
@@ -199,7 +156,6 @@ display:
           multi_type: separator
           separator: ', '
           field_api_classes: false
-          plugin_id: field
         localgov_step_section_title:
           id: localgov_step_section_title
           table: node__localgov_step_section_title
@@ -207,6 +163,7 @@ display:
           relationship: localgov_step_by_step_pages_1
           group_type: group
           admin_label: ''
+          plugin_id: field
           label: ''
           exclude: false
           alter:
@@ -236,7 +193,7 @@ display:
             trim: false
             preserve_tags: ''
             html: false
-          element_type: div
+          element_type: h2
           element_class: step__title
           element_label_type: ''
           element_label_class: ''
@@ -262,7 +219,6 @@ display:
           multi_type: separator
           separator: ', '
           field_api_classes: false
-          plugin_id: field
         localgov_step_summary:
           id: localgov_step_summary
           table: node__localgov_step_summary
@@ -270,6 +226,7 @@ display:
           relationship: localgov_step_by_step_pages_1
           group_type: group
           admin_label: ''
+          plugin_id: field
           label: ''
           exclude: false
           alter:
@@ -324,7 +281,71 @@ display:
           multi_type: separator
           separator: ', '
           field_api_classes: false
-          plugin_id: field
+      pager:
+        type: none
+        options:
+          offset: 0
+      exposed_form:
+        type: basic
+        options:
+          submit_button: Apply
+          reset_button: false
+          reset_button_label: Reset
+          exposed_sorts_label: 'Sort by'
+          expose_sort_order: true
+          sort_asc_label: Asc
+          sort_desc_label: Desc
+      access:
+        type: perm
+        options:
+          perm: 'access content'
+      cache:
+        type: tag
+        options: {  }
+      empty: {  }
+      sorts: {  }
+      arguments:
+        nid:
+          id: nid
+          table: node_field_data
+          field: nid
+          relationship: localgov_step_by_step_pages
+          group_type: group
+          admin_label: 'Step by step page node ID'
+          entity_type: node
+          entity_field: nid
+          plugin_id: node_nid
+          default_action: default
+          exception:
+            value: all
+            title_enable: false
+            title: All
+          title_enable: false
+          title: ''
+          default_argument_type: node
+          default_argument_options: {  }
+          default_argument_skip_url: false
+          summary_options:
+            base_path: ''
+            count: true
+            override: false
+            items_per_page: 25
+          summary:
+            sort_order: asc
+            number_of_records: 0
+            format: default_summary
+          specify_validation: true
+          validate:
+            type: 'entity:node'
+            fail: 'access denied'
+          validate_options:
+            bundles:
+              localgov_step_by_step_page: localgov_step_by_step_page
+            access: false
+            operation: view
+            multiple: 0
+          break_phrase: false
+          not: false
       filters:
         status_extra:
           id: status_extra
@@ -333,6 +354,8 @@ display:
           relationship: localgov_step_by_step_pages_1
           group_type: group
           admin_label: ''
+          entity_type: node
+          plugin_id: node_status
           operator: '='
           value: false
           group: 1
@@ -363,13 +386,34 @@ display:
             default_group: All
             default_group_multiple: {  }
             group_items: {  }
-          entity_type: node
-          plugin_id: node_status
-      sorts: {  }
-      title: 'Step by step navigation'
-      header: {  }
-      footer: {  }
-      empty: {  }
+      filter_groups:
+        operator: AND
+        groups:
+          1: AND
+      style:
+        type: html_list
+        options:
+          grouping: {  }
+          row_class: step
+          default_row_class: false
+          type: ol
+          wrapper_class: ''
+          class: step-list
+      row:
+        type: fields
+        options:
+          default_field_elements: false
+          inline: {  }
+          separator: ''
+          hide_empty: false
+      query:
+        type: views_query
+        options:
+          query_comment: ''
+          disable_sql_rewrite: false
+          distinct: false
+          replica: false
+          query_tags: {  }
       relationships:
         localgov_step_by_step_pages:
           id: localgov_step_by_step_pages
@@ -378,8 +422,8 @@ display:
           relationship: none
           group_type: group
           admin_label: 'Step by step pages referenced from Step by step overviews'
-          required: false
           plugin_id: standard
+          required: false
         reverse__node__localgov_step_by_step_pages:
           id: reverse__node__localgov_step_by_step_pages
           table: node_field_data
@@ -387,9 +431,9 @@ display:
           relationship: localgov_step_by_step_pages
           group_type: group
           admin_label: 'Step by step overviews'
-          required: false
           entity_type: node
           plugin_id: entity_reverse
+          required: false
         localgov_step_by_step_pages_1:
           id: localgov_step_by_step_pages_1
           table: node__localgov_step_by_step_pages
@@ -397,56 +441,12 @@ display:
           relationship: reverse__node__localgov_step_by_step_pages
           group_type: group
           admin_label: 'Step by step pages referenced from Step by step overviews'
-          required: true
           plugin_id: standard
-      arguments:
-        nid:
-          id: nid
-          table: node_field_data
-          field: nid
-          relationship: localgov_step_by_step_pages
-          group_type: group
-          admin_label: 'Step by step page node ID'
-          default_action: default
-          exception:
-            value: all
-            title_enable: false
-            title: All
-          title_enable: false
-          title: ''
-          default_argument_type: node
-          default_argument_options: {  }
-          default_argument_skip_url: false
-          summary_options:
-            base_path: ''
-            count: true
-            items_per_page: 25
-            override: false
-          summary:
-            sort_order: asc
-            number_of_records: 0
-            format: default_summary
-          specify_validation: true
-          validate:
-            type: 'entity:node'
-            fail: 'access denied'
-          validate_options:
-            bundles:
-              localgov_step_by_step_page: localgov_step_by_step_page
-            operation: view
-            multiple: 0
-            access: false
-          break_phrase: false
-          not: false
-          entity_type: node
-          entity_field: nid
-          plugin_id: node_nid
-      display_comment: "Lists Step by step pages belonging to a Step by step *overview*.  This overview is derived either from the current page or from the currently displayed Step by step page.\r\n\r\nThe blocks from the \"Navigation block\" and \"Prev/Next step\" displays are meant to be used in Step by step pages only.  The \"Overview navigation block\" is meant to be used in Step by step overviews.\r\n\r\nWe use a custom theme template for the \"Prev/Next step\" display.  Custom theme template variables are inserted from a template preprocess function.  This function is dependent on the content ID field whose column name is node_field_data_node__localgov_step_by_step_pages_1_nid at present.\r\n@see localgov_step_by_step_preprocess_views_view_list()\r\n@see modules/custom/localgov_step_by_step/views-view-list--step-by-step-navigation--prev-next.html.twig"
+          required: true
       css_class: step-by-step-pages
-      filter_groups:
-        operator: AND
-        groups:
-          1: AND
+      header: {  }
+      footer: {  }
+      display_comment: "Lists Step by step pages belonging to a Step by step *overview*.  This overview is derived either from the current page or from the currently displayed Step by step page.\r\n\r\nThe blocks from the \"Navigation block\" and \"Prev/Next step\" displays are meant to be used in Step by step pages only.  The \"Overview navigation block\" is meant to be used in Step by step overviews.\r\n\r\nWe use a custom theme template for the \"Prev/Next step\" display.  Custom theme template variables are inserted from a template preprocess function.  This function is dependent on the content ID field whose column name is node_field_data_node__localgov_step_by_step_pages_1_nid at present.\r\n@see localgov_step_by_step_preprocess_views_view_list()\r\n@see modules/custom/localgov_step_by_step/views-view-list--step-by-step-navigation--prev-next.html.twig"
       display_extenders: {  }
     cache_metadata:
       max-age: -1
@@ -462,19 +462,11 @@ display:
         - 'config:field.storage.node.localgov_step_section_title'
         - 'config:field.storage.node.localgov_step_summary'
   prev_next:
-    display_plugin: block
     id: prev_next
     display_title: 'Prev-Next block'
+    display_plugin: block
     position: 2
     display_options:
-      display_description: ''
-      block_description: 'Prev/Next step'
-      defaults:
-        fields: true
-        style: false
-        row: false
-        css_class: false
-      css_class: 'step-by-step-pages step-by-step--prev-next'
       style:
         type: html_list
         options:
@@ -491,7 +483,15 @@ display:
           inline: {  }
           separator: ''
           hide_empty: false
+      defaults:
+        css_class: false
+        style: false
+        row: false
+        fields: true
+      css_class: 'step-by-step-pages step-by-step--prev-next'
+      display_description: ''
       display_extenders: {  }
+      block_description: 'Prev/Next step'
     cache_metadata:
       max-age: -1
       contexts:
@@ -506,12 +506,17 @@ display:
         - 'config:field.storage.node.localgov_step_section_title'
         - 'config:field.storage.node.localgov_step_summary'
   steps:
-    display_plugin: block
     id: steps
     display_title: 'Navigation block'
+    display_plugin: block
     position: 1
     display_options:
-      block_description: 'Step by step navigation'
+      defaults:
+        css_class: false
+        style: true
+        row: true
+        header: false
+      css_class: 'step-by-step-pages step-by-step-pages--nav'
       display_description: ''
       header:
         area_text_custom:
@@ -521,17 +526,12 @@ display:
           relationship: none
           group_type: group
           admin_label: 'Pointer to Step by step overview'
-          empty: false
-          tokenize: true
-          content: "<div  class=\"step-by-step-pages__relationship\">\r\n  <span class=\"step-by-step-pages__part-of\">Part of </span><br/>\r\n  <span class=\"step-by-step-pages__overview\">{{ localgov_step_parent }}</span>\r\n</div>"
           plugin_id: text_custom
-      defaults:
-        header: false
-        style: true
-        row: true
-        css_class: false
-      css_class: 'step-by-step-pages step-by-step-pages--nav'
+          empty: false
+          content: "<div  class=\"step-by-step-pages__relationship\">\r\n  <span class=\"step-by-step-pages__part-of\">Part of </span><br/>\r\n  <span class=\"step-by-step-pages__overview\">{{ localgov_step_parent }}</span>\r\n</div>"
+          tokenize: true
       display_extenders: {  }
+      block_description: 'Step by step navigation'
     cache_metadata:
       max-age: -1
       contexts:
@@ -546,9 +546,9 @@ display:
         - 'config:field.storage.node.localgov_step_section_title'
         - 'config:field.storage.node.localgov_step_summary'
   steps_for_overview:
-    display_plugin: block
     id: steps_for_overview
     display_title: 'Overview navigation block'
+    display_plugin: block
     position: 3
     display_options:
       arguments:
@@ -559,6 +559,9 @@ display:
           relationship: none
           group_type: group
           admin_label: 'Step by step overview node ID'
+          entity_type: node
+          entity_field: nid
+          plugin_id: node_nid
           default_action: default
           exception:
             value: all
@@ -572,8 +575,8 @@ display:
           summary_options:
             base_path: ''
             count: true
-            items_per_page: 25
             override: false
+            items_per_page: 25
           summary:
             sort_order: asc
             number_of_records: 0
@@ -585,18 +588,15 @@ display:
           validate_options:
             bundles:
               localgov_step_by_step_overview: localgov_step_by_step_overview
+            access: false
             operation: view
             multiple: 0
-            access: false
           break_phrase: false
           not: false
-          entity_type: node
-          entity_field: nid
-          plugin_id: node_nid
       defaults:
-        arguments: false
-        relationships: false
         css_class: false
+        relationships: false
+        arguments: false
       relationships:
         localgov_step_by_step_pages_1:
           id: localgov_step_by_step_pages_1
@@ -605,12 +605,12 @@ display:
           relationship: none
           group_type: group
           admin_label: 'Step by step pages referenced from Step by step overviews'
-          required: true
           plugin_id: standard
+          required: true
       css_class: 'step-by-step-pages step-by-step-pages--nav'
       display_description: 'List Step by step pages belonging to a Step by step overview.'
-      block_description: 'Step by step navigation for Step overview'
       display_extenders: {  }
+      block_description: 'Step by step navigation for Step overview'
     cache_metadata:
       max-age: -1
       contexts:

--- a/localgov_step_by_step.install
+++ b/localgov_step_by_step.install
@@ -107,3 +107,28 @@ EOY
     return t('Step by step navigation view not updated. See release notes for more info.');
   }
 }
+
+/**
+ * Update navigation view for step title h2.
+ */
+function localgov_step_by_step_update_8002() {
+  $navigation_view = View::load('localgov_step_by_step_navigation');
+  $display = $navigation_view->get('display');
+  $fields = $display['default']['display_options']['fields'];
+  // Don't alter the view if the relevant parts have been changed on the site.
+  if (
+    isset($fields['localgov_step_section_title']) &&
+    ($section_title = $fields['localgov_step_section_title']) &&
+    ($section_title['element_class'] == 'step__title') &&
+    ($section_title['element_type'] == 'div')
+  ) {
+    $display['default']['display_options']['fields']['localgov_step_section_title']['element_type'] = 'h2';
+    $navigation_view->set('display', $display);
+    $navigation_view->save();
+    return t('Step by step navigation view step title changed from div to h2.');
+  }
+  else {
+    return t('Step by step navigation view not updated. See release notes for more info.');
+  }
+
+}


### PR DESCRIPTION
Sets step title as h2 instead of div (#69)

* sets step title as h2 instead of div
* Set step title as h2 for existing sites.

If you have updated the view of steps the change might not be applied to your site. If so you may want to update the step titles to use an H2 instead of a DIV manually. See also https://github.com/localgovdrupal/localgov_step_by_step/issues/37