### PR TITLE
Make summary visible on step by step overview edit page

### DIFF
--- a/config/install/core.entity_form_display.node.localgov_step_by_step_overview.default.yml
+++ b/config/install/core.entity_form_display.node.localgov_step_by_step_overview.default.yml
@@ -21,6 +21,7 @@ content:
       rows: 9
       summary_rows: 3
       placeholder: ''
+      show_summary: true
     third_party_settings: {  }
     region: content
   created:


### PR DESCRIPTION
Fixes #75

With this change then overview edit page looks like:

![image](https://user-images.githubusercontent.com/7189914/236248123-df30a0dd-0b3c-4c0b-9c75-b5387631cd5a.png)
