### PR TITLE
Fix: Suppressing PHP 8.2 deprecation warnings

### DIFF
--- a/src/Plugin/Block/StepPartOfBlock.php
+++ b/src/Plugin/Block/StepPartOfBlock.php
@@ -44,6 +44,13 @@ class StepPartOfBlock extends BlockBase implements ContainerFactoryPluginInterfa
   protected $node;
 
   /**
+   * Current route object.
+   *
+   * @var \Drupal\Core\Routing\ResettableStackedRouteMatchInterface
+   */
+  protected $routeMatch;
+
+  /**
    * {@inheritdoc}
    */
   public static function create(ContainerInterface $container, array $configuration, $plugin_id, $plugin_definition) {


### PR DESCRIPTION
Suppressing PHP 8.2's dynamic property deprecation warnings.

@see https://www.php.net/releases/8.2/en.php#deprecate_dynamic_properties