### PR TITLE
Fix issue with accessible label

### DIFF
--- a/js/step-by-step-nav.js
+++ b/js/step-by-step-nav.js
@@ -20,7 +20,7 @@
           $(this).parents('.step').find('.step__summary').addClass('step-show-summary');
           $(this).text(stepByStep.hideStepText);
           $(this).attr("aria-expanded", "true");
-          $(this).attr('aria-label', "Hide " + stepTitle + " summary");
+          $(this).attr('aria-label', "Hide step summary - " + stepTitle);
         });
         // 'Hide all' control displayed if all steps are shown.
         if ($('.step__summary').length === $('.step-show-summary').length) {
@@ -35,7 +35,7 @@
           $(this).parents('.step').find('.step__summary').removeClass('step-show-summary');
           $(this).attr("aria-expanded", "false");
           $(this).text(stepByStep.showStepText);
-          $(this).attr('aria-label', "Show " + stepTitle + " summary");
+          $(this).attr('aria-label', "Show step summary - " + stepTitle);
         });
         // 'Show all' control displayed if any steps are hidden.
         $('.step-master').text(stepByStep.showAllText);
@@ -52,7 +52,11 @@
     var $container = $("<span class='step-summary-container'>");
     var $button = $("<button class='step-show'>");
     $button.attr('aria-expanded', isVisible ? "true" : "false");
-    $button.attr('aria-label', (isVisible ? "Hide " : "Show ") + stepTitle + " summary");
+    if (isVisible) {
+      $button.attr('aria-label', Drupal.t("Hide step summary - !summary_message", {"!summary_message": stepTitle}));
+    } else {
+      $button.attr('aria-label', Drupal.t("Show step summary - !summary_message", {"!summary_message": stepTitle}));
+    }
     $button.text(isVisible ? stepByStep.hideStepText : stepByStep.showStepText);
     $container.append($button);
     return $container;

--- a/js/step-by-step-nav.js
+++ b/js/step-by-step-nav.js
@@ -20,7 +20,7 @@
           $(this).parents('.step').find('.step__summary').addClass('step-show-summary');
           $(this).text(stepByStep.hideStepText);
           $(this).attr("aria-expanded", "true");
-          $(this).attr('aria-label', "Hide step summary - " + stepTitle);
+          $(this).attr('aria-label', Drupal.t("Hide step summary - !summary_message", {"!summary_message": stepTitle}));
         });
         // 'Hide all' control displayed if all steps are shown.
         if ($('.step__summary').length === $('.step-show-summary').length) {
@@ -35,7 +35,7 @@
           $(this).parents('.step').find('.step__summary').removeClass('step-show-summary');
           $(this).attr("aria-expanded", "false");
           $(this).text(stepByStep.showStepText);
-          $(this).attr('aria-label', "Show step summary - " + stepTitle);
+          $(this).attr('aria-label',  Drupal.t("Show step summary - !summary_message", {"!summary_message": stepTitle}));
         });
         // 'Show all' control displayed if any steps are hidden.
         $('.step-master').text(stepByStep.showAllText);


### PR DESCRIPTION
<!-- See https://docs.localgovdrupal.org/contributing/ for guidelines on contributing. -->

## What does this change?

It changes the aria-label to use the same text of the button at the start of the label to satisfy the WCAG requirements.

## How to test

Use something like Siteimprove and should no longer flag the isue.

## How can we measure success?
Clients should see less errors reported by tools like Siteimprove for this particular issue. 

## Have we considered potential risks?

There should be no additional risks than before.

## Images

Before:
![Screenshot 2024-08-20 at 12 03 59](https://github.com/user-attachments/assets/e231d489-2919-4910-9de3-2fa889561860)

After:
![Screenshot 2024-08-20 at 12 17 44](https://github.com/user-attachments/assets/39e3b6b6-c379-4cc1-9070-73df8771a305)


## Accessibility

-   [X] [Tested with screen reader](https://github.com/guardian/accessibility/blob/main/people-and-technology/03-visual.md#screen-reader)
-   [X] [Navigable with keyboard](https://github.com/guardian/accessibility/blob/main/people-and-technology/02-physical.md#keyboard)
-   [X] [Colour contrast passed](https://github.com/guardian/accessibility/blob/main/people-and-technology/03-visual.md#contrast)
-   [X] [The change doesn't use only colour to convey meaning](https://github.com/guardian/accessibility/blob/main/people-and-technology/03-visual.md#use-of-colour)