### PR TITLE
adds aria-current to current step

### DIFF
--- a/localgov_step_by_step.module
+++ b/localgov_step_by_step.module
@@ -247,6 +247,7 @@ function _localgov_step_by_step_mark_current_step(string $current_nid, array &$v
     $is_current_step = ($row_nid === $current_nid);
     if ($is_current_step) {
       $row['attributes']['class'][] = 'step--active';
+      $row['attributes']['aria-current'] = 'step';
       break;
     }
   }


### PR DESCRIPTION
Closes #117 

## What does this change?

Adds `aria-current="stop"` to the current page item in a step-by-step navigation.

## How to test

Click on a step-by-step page, inspect the HTML of the current page in the step-by-step navigation, it should have an `aria-current="step"` attribute.

## Images

![Screenshot 2024-09-24 at 14 34 29](https://github.com/user-attachments/assets/372d1145-34ab-415f-bc50-e2c174c5680a)

---
Thanks to [Big Blue Door](https://www.bigbluedoor.net/) for sponsoring my time to work on this.