### PR TITLE
Feature/2.x/126 step part of block does not use current language

### DIFF
--- a/src/Plugin/Block/StepPartOfBlock.php
+++ b/src/Plugin/Block/StepPartOfBlock.php
@@ -101,7 +101,8 @@ class StepPartOfBlock extends BlockBase implements ContainerFactoryPluginInterfa
       $langcode = $this->node->langcode->value;
       if ($this->node->isDefaultTranslation()) {
         $parent_entity = $this->node->localgov_step_parent->entity;
-      } elseif ($this->node->localgov_step_parent->entity->hasTranslation($langcode)) {
+      }
+      elseif ($this->node->localgov_step_parent->entity->hasTranslation($langcode)) {
         $parent_entity = $this->node->localgov_step_parent->entity->getTranslation($langcode);
       }
       $build[] = [

--- a/src/Plugin/Block/StepPartOfBlock.php
+++ b/src/Plugin/Block/StepPartOfBlock.php
@@ -99,11 +99,17 @@ class StepPartOfBlock extends BlockBase implements ContainerFactoryPluginInterfa
 
     if ($this->node->localgov_step_parent && $this->node->localgov_step_parent->entity) {
       $langcode = $this->node->langcode->value;
+      // If this is the default translation.
       if ($this->node->isDefaultTranslation()) {
         $parent_entity = $this->node->localgov_step_parent->entity;
       }
+      // If this is a translation and the parent's also translated.
       elseif ($this->node->localgov_step_parent->entity->hasTranslation($langcode)) {
         $parent_entity = $this->node->localgov_step_parent->entity->getTranslation($langcode);
+      }
+      else {
+        // If the current node is translated, but the parent node isn't.
+        $parent_entity = $this->node->localgov_step_parent->entity;
       }
       $build[] = [
         '#theme' => 'step_by_step_part_of_block',

--- a/src/Plugin/Block/StepPartOfBlock.php
+++ b/src/Plugin/Block/StepPartOfBlock.php
@@ -98,11 +98,18 @@ class StepPartOfBlock extends BlockBase implements ContainerFactoryPluginInterfa
     $build = [];
 
     if ($this->node->localgov_step_parent && $this->node->localgov_step_parent->entity) {
+      $langcode = $this->node->langcode->value;
+      if ($this->node->isDefaultTranslation()) {
+        $parent_entity = $this->node->localgov_step_parent->entity;
+      } elseif ($this->node->localgov_step_parent->entity->hasTranslation($langcode)) {
+        $parent_entity = $this->node->localgov_step_parent->entity->getTranslation($langcode);
+      }
       $build[] = [
         '#theme' => 'step_by_step_part_of_block',
-        '#label' => $this->node->localgov_step_parent->entity->label(),
-        '#url' => $this->node->localgov_step_parent->entity->toUrl(),
+        '#label' => $parent_entity->label(),
+        '#url' => $parent_entity->toUrl(),
       ];
+      $build['#cache']['contexts'][] = 'languages:language_interface';
     }
 
     return $build;
@@ -122,7 +129,7 @@ class StepPartOfBlock extends BlockBase implements ContainerFactoryPluginInterfa
    * {@inheritdoc}
    */
   public function getCacheContexts() {
-    return Cache::mergeContexts(parent::getCacheContexts(), ['route']);
+    return Cache::mergeContexts(parent::getCacheContexts(), ['languages:language_interface', 'route']);
   }
 
 }

--- a/templates/step-by-step-part-of-block.html.twig
+++ b/templates/step-by-step-part-of-block.html.twig
@@ -9,6 +9,6 @@
 */
 #}
 <div class="step-by-step-pages__relationship">
-  <span class="step-by-step-pages__part-of">Part of </span><br/>
+  <span class="step-by-step-pages__part-of">{{ 'Part of'|t }}</span><br/>
   <span class="step-by-step-pages__homepage"> <a href="{{ url }}" title="{{ label }}">{{ label }}</a></span>
 </div>


### PR DESCRIPTION
<!-- See https://docs.localgovdrupal.org/contributing/ for guidelines on contributing. -->

Re: #126 

## What does this change?

<!-- A pull request should have enough detail to be understandable far in the
future. e.g what is the problem/why is the change needed, how does it solve it
and any questions or points of discussion. Prefer copying information from a
Trello card (for example) over linking to it; the card may not always exist and
reviewers may not have access to the board. -->

This PR makes the following changes:

1. makes the ["Part of" string in `step-by-step-part-of-block.html.twig`](https://github.com/localgovdrupal/localgov_step_by_step/blob/2.x/templates/step-by-step-part-of-block.html.twig#L12) translateable,
2. makes the `StepPartOfBlock.php` plugin use the current page language when:
  - the current (Step by step step) page is _not_ the default translation, _and_
  - the parent (Step by step overview) page is translated into the language of the current page

## How to test

<!-- Provide instructions to help others verify the change. This could take the
form of "On main, do X and witness Y. On this branch, do X and witness Z. " -->

On a multilingual LGD site:

**Note**: translating Step by step content badly breaks the step views on both content types, but that's a) outside the scope of this PR, and b) fixable in config.

- create a new Step by step overview node
- translate the new node
- create one or more Step by step step nodes using the newly-created Step by step overview as the parent
- translate each new Step by step step nodes
- while logged out (or from a private browser window), toggle the site language

Check the following:

- [ ] the translated Step by step overview node title is used in the "Part of ..." portion of the block when switching to the non-default language (**note**: "Part of" won't be automatically translated)
- [ ] the block does not get cached in the translated language and show up on the default language version of the page (!)

## How can we measure success?

<!-- Do you expect errors to decrease? Do you expect user journeys to be
simplified? What can be used to prove this? A filtered view of logs or
analytics, etc? -->

I suggest two criteria for success:

1. not needing to handle the translation language issues in Twig,
2. not breaking the block by permitting it to be cached on the page in the wrong language.

## Have we considered potential risks?

<!-- What are the potential risks and how can they be mitigated? Does an error
require an alarm? Should user help, infosec, or legal be informed of this
change? Is private information guarded? Do we need to add anything in the
backlog? -->

Assuming I've got (2) above right, there are no special risks.

## Images

n/a

## Accessibility

n/a